### PR TITLE
Add equipo and pulsera retrieval helpers

### DIFF
--- a/pulseras/pulsera_functions.php
+++ b/pulseras/pulsera_functions.php
@@ -38,4 +38,29 @@ function getTotalEventos($conexion, $id_pulsera) {
     $result = $stmt->get_result();
     return $result->fetch_assoc()['total'];
 }
+
+function getEquiposUsuario($conexion, $user_id) {
+    $query = "SELECT id, nombre_equipo FROM equipos WHERE responsable_equipo = ?";
+    $stmt = $conexion->prepare($query);
+    $stmt->bind_param("i", $user_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $equipos = $result->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+    return $equipos;
+}
+
+function getPulserasEquipo($conexion, $equipo_id) {
+    $query = "SELECT p.id AS id_pulsera, p.alias, p.funcionamiento
+              FROM pulseras p
+              INNER JOIN pulserasxequipo px ON p.id = px.pulsera_id
+              WHERE px.equipo_id = ?";
+    $stmt = $conexion->prepare($query);
+    $stmt->bind_param("i", $equipo_id);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    $pulseras = $result->fetch_all(MYSQLI_ASSOC);
+    $stmt->close();
+    return $pulseras;
+}
 ?>


### PR DESCRIPTION
## Summary
- Define `getEquiposUsuario` to fetch equipos managed by a user
- Define `getPulserasEquipo` to list pulseras associated to an equipo

## Testing
- `php -l pulseras/pulsera_functions.php`
- `php -l pulseras/selector_pulsera.php`


------
https://chatgpt.com/codex/tasks/task_e_68a520edc490832383173d9349eb7267