### PR TITLE
refactor: centralize equipo and pulsera retrieval

### DIFF
--- a/pulseras/backend/pulsera_functions.php
+++ b/pulseras/backend/pulsera_functions.php
@@ -63,4 +63,20 @@ function getPulserasEquipo($conexion, $equipo_id) {
     $stmt->close();
     return $pulseras;
 }
+
+/**
+ * Obtiene todos los equipos del usuario junto con sus pulseras asociadas.
+ *
+ * @param mysqli $conexion Conexión a la base de datos.
+ * @param int    $user_id  ID del usuario.
+ * @return array Lista de equipos con el arreglo 'pulseras' incluido.
+ */
+function getEquiposConPulseras($conexion, $user_id) {
+    $equipos = getEquiposUsuario($conexion, $user_id);
+    foreach ($equipos as &$equipo) {
+        $equipo['pulseras'] = getPulserasEquipo($conexion, $equipo['id']);
+    }
+    unset($equipo); // Romper la referencia para evitar efectos secundarios
+    return $equipos;
+}
 ?>

--- a/pulseras/frontend/selector_pulsera.php
+++ b/pulseras/frontend/selector_pulsera.php
@@ -14,16 +14,8 @@ $additionalHeadContent = '<script src="js/selector_pulsera.js"></script>';
 
 ob_start();
 
-// Obtener todos los equipos donde el usuario es responsable
-$equipos = getEquiposUsuario($conexion, $_SESSION['user_id']);
-
-// Para cada equipo, obtener sus pulseras
-$equiposTemp = [];
-foreach ($equipos as $equipo) {
-    $equipo['pulseras'] = getPulserasEquipo($conexion, $equipo['id']);
-    $equiposTemp[] = $equipo;
-$equipos = $equiposTemp; // Reemplazar el array original con el procesado
-}
+// Obtener todos los equipos donde el usuario es responsable con sus pulseras
+$equipos = getEquiposConPulseras($conexion, $_SESSION['user_id']);
 // Si se selecciona una pulsera, redirigir al dashboard
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['seleccion'])) {
     $parts = explode(':', $_POST['seleccion']);


### PR DESCRIPTION
### Summary
- add helper to fetch equipos with their pulseras
- use helper in selector to reduce duplication

### Testing
- `php -l pulseras/backend/pulsera_functions.php`
- `php -l pulseras/frontend/selector_pulsera.php`


------
https://chatgpt.com/codex/tasks/task_e_68a531a07a3083239a7799e180f7851f