### PR TITLE
Add heartbeat coordinates to dashboard

### DIFF
--- a/pulseras/backend/get_estado.php
+++ b/pulseras/backend/get_estado.php
@@ -24,7 +24,7 @@ $conn->set_charset('utf8mb4');
 
 // 4) Traer el último latido de esa pulsera
 $sql = "
-    SELECT received_at, battery_mv
+    SELECT received_at, battery_mv, latitude, longitude
     FROM pulseras_heartbeat
     WHERE pulsera_id = ?
     ORDER BY received_at DESC
@@ -44,6 +44,8 @@ $result = $stmt->get_result();
 if ($row = $result->fetch_assoc()) {
     $last_seen   = $row['received_at']; // 'Y-m-d H:i:s'
     $battery_mv  = is_null($row['battery_mv']) ? null : intval($row['battery_mv']);
+    $latitude    = is_null($row['latitude']) ? null : (float)$row['latitude'];
+    $longitude   = is_null($row['longitude']) ? null : (float)$row['longitude'];
 
     // 5) Calcular minutos transcurridos y estado
     $now = new DateTime('now');
@@ -59,7 +61,9 @@ if ($row = $result->fetch_assoc()) {
         'last_seen'      => $last_seen,
         'battery_mv'     => $battery_mv,
         'minutes_since'  => $minutes_since,
-        'estado'         => $estado
+        'estado'         => $estado,
+        'latitude'       => $latitude,
+        'longitude'      => $longitude
     ]);
 } else {
     // No hay latidos registrados para esa pulsera
@@ -69,7 +73,9 @@ if ($row = $result->fetch_assoc()) {
         'last_seen'     => null,
         'battery_mv'    => null,
         'minutes_since' => null,
-        'estado'        => 'sin datos'
+        'estado'        => 'sin datos',
+        'latitude'      => null,
+        'longitude'     => null
     ]);
 }
 

--- a/pulseras/frontend/dashboard.php
+++ b/pulseras/frontend/dashboard.php
@@ -61,9 +61,9 @@ ob_start();
                 <div class="card h-100">
                     <div class="card-body">
                         <h5 class="card-title mb-4">Mapa</h5>
-                        <div class="d-flex justify-content-center">
-                            <iframe width="100%" height="350" src="https://www.openstreetmap.org/export/embed.html?bbox=-58.58048558235169%2C-34.5898699395%2C-58.57044339179993%2C-34.58386370936635&amp;layer=mapnik" style="border: 1px solid black"></iframe>
-                        </div>
+        <div class="d-flex justify-content-center">
+            <iframe id="map" width="100%" height="350" style="border: 1px solid black"></iframe>
+        </div>
                     </div>
                 </div>
             </div>

--- a/pulseras/frontend/js/dashboard.js
+++ b/pulseras/frontend/js/dashboard.js
@@ -1,6 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
   const ENDPOINT = '../backend/get_estado.php'; // <--- AJUSTA ESTA RUTA
   const el = document.getElementById('estado-boton');
+  const mapEl = document.getElementById('map');
 
   if (!el) {
     console.error('No existe #estado-boton en el DOM');
@@ -57,6 +58,20 @@ document.addEventListener('DOMContentLoaded', () => {
         <br><small>Último latido: ${fmtLastSeen(data.last_seen)} (${fmtMinutes(data.minutes_since)})</small>
         <br><small>Batería: ${fmtBattery(data.battery_mv)}</small>
       `;
+
+      if (mapEl && data.latitude != null && data.longitude != null) {
+        const lat = parseFloat(data.latitude);
+        const lon = parseFloat(data.longitude);
+        const dLat = 0.003;
+        const dLon = 0.005;
+        const bbox = [
+          (lon - dLon).toFixed(7),
+          (lat - dLat).toFixed(7),
+          (lon + dLon).toFixed(7),
+          (lat + dLat).toFixed(7)
+        ];
+        mapEl.src = `https://www.openstreetmap.org/export/embed.html?bbox=${bbox[0]}%2C${bbox[1]}%2C${bbox[2]}%2C${bbox[3]}&layer=mapnik&marker=${lat}%2C${lon}`;
+      }
     } catch (e) {
       setClass('error');
       el.innerHTML = `<span class="fw-semibold">Error</span><br>

--- a/sql/nes.sql
+++ b/sql/nes.sql
@@ -124,15 +124,17 @@ CREATE TABLE `pulseras_heartbeat` (
   `id` bigint(20) UNSIGNED NOT NULL,
   `pulsera_id` int(11) NOT NULL,
   `received_at` datetime NOT NULL DEFAULT current_timestamp(),
-  `battery_mv` smallint(5) UNSIGNED DEFAULT NULL
+  `battery_mv` smallint(5) UNSIGNED DEFAULT NULL,
+  `latitude` decimal(10,7) DEFAULT NULL,
+  `longitude` decimal(10,7) DEFAULT NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 
 --
 -- Volcado de datos para la tabla `pulseras_heartbeat`
 --
 
-INSERT INTO `pulseras_heartbeat` (`id`, `pulsera_id`, `received_at`, `battery_mv`) VALUES
-(3, 1, '2025-08-19 23:11:44', 3740);
+INSERT INTO `pulseras_heartbeat` (`id`, `pulsera_id`, `received_at`, `battery_mv`, `latitude`, `longitude`) VALUES
+(3, 1, '2025-08-19 23:11:44', 3740, NULL, NULL);
 
 -- --------------------------------------------------------
 

--- a/webhook/latido.php
+++ b/webhook/latido.php
@@ -49,19 +49,27 @@ if (array_key_exists('battery_mv', $data) && $data['battery_mv'] !== '' && $data
     $mv = (int)$data['battery_mv'];
     if ($mv <= 0) { $mv = null; }
 }
+$lat = null;
+if (array_key_exists('latitude', $data) && $data['latitude'] !== '' && $data['latitude'] !== null) {
+    $lat = (float)$data['latitude'];
+}
+$lon = null;
+if (array_key_exists('longitude', $data) && $data['longitude'] !== '' && $data['longitude'] !== null) {
+    $lon = (float)$data['longitude'];
+}
 
 try {
     $stmt = $pdo->prepare("
-        INSERT INTO pulseras_heartbeat (pulsera_id, battery_mv)
-        VALUES (:id, :mv)
+        INSERT INTO pulseras_heartbeat (pulsera_id, battery_mv, latitude, longitude)
+        VALUES (:id, :mv, :lat, :lon)
     ");
-    $stmt->execute([':id' => $id, ':mv' => $mv]);
+    $stmt->execute([':id' => $id, ':mv' => $mv, ':lat' => $lat, ':lon' => $lon]);
 
     $newId = (int)$pdo->lastInsertId();
 
     // Leer el registro para devolver received_at exacto
     $stmt2 = $pdo->prepare("
-        SELECT received_at, battery_mv
+        SELECT received_at, battery_mv, latitude, longitude
         FROM pulseras_heartbeat
         WHERE id = :rid
         LIMIT 1
@@ -81,6 +89,8 @@ try {
         'id'          => $newId,
         'id_pulsera'  => $id,
         'battery_mv'  => is_null($row['battery_mv']) ? null : (int)$row['battery_mv'],
+        'latitude'    => is_null($row['latitude']) ? null : (float)$row['latitude'],
+        'longitude'   => is_null($row['longitude']) ? null : (float)$row['longitude'],
         'received_at' => $lastSeenIso
     ]);
 } catch (PDOException $e) {


### PR DESCRIPTION
## Summary
- add latitude and longitude columns to `pulseras_heartbeat`
- capture coordinates in webhook and expose them via API
- update dashboard to render OSM map using last heartbeat location

## Testing
- `php -l pulseras/backend/get_estado.php`
- `php -l webhook/latido.php`
- `php -l pulseras/frontend/dashboard.php`
- `node --check pulseras/frontend/js/dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68a5efaaeebc8323a969883ced9648e0