### PR TITLE
Use bcrypt for password hashing

### DIFF
--- a/auth/register.php
+++ b/auth/register.php
@@ -9,7 +9,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $password = $_POST['password'];
     
     // Hash de la contraseña usando bcrypt
-    $hashed_password = password_hash($password, PASSWORD_DEFAULT);
+    $hashed_password = password_hash($password, PASSWORD_BCRYPT, ['cost' => 12]);
     
     try {
         $stmt = $pdo->prepare("INSERT INTO usuarios (nombre, email, contraseña, direccion) VALUES (?, ?, ?, ?)");


### PR DESCRIPTION
## Summary
- explicitly use bcrypt when hashing passwords during registration

## Testing
- `php -l auth/register.php auth/login.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6196ba57c8323986d852d5157f9a6